### PR TITLE
Update repo name to rancherlabs

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -23,7 +23,7 @@ steps:
     dockerfile: github-bot/Dockerfile
     password:
       from_secret: docker_password
-    repo: rancher/harvester-github-bot
+    repo: rancherlabs/harvester-github-bot
     tag: "master"
     username:
       from_secret: docker_username
@@ -45,7 +45,7 @@ steps:
     dockerfile: github-bot/Dockerfile
     password:
       from_secret: docker_password
-    repo: rancher/harvester-github-bot
+    repo: rancherlabs/harvester-github-bot
     tag: "master"
     username:
       from_secret: docker_username


### PR DESCRIPTION
Update repo name to `rancherlabs` per EIO's comment.
> Repository created on Docker Hub: https://hub.docker.com/repository/docker/rancherlabs/harvester-github-bot

