### PR TITLE
Fix release is automatically associated when a backport issue is created.

### DIFF
--- a/github-bot/harvester_github_bot/backport.py
+++ b/github-bot/harvester_github_bot/backport.py
@@ -75,7 +75,7 @@ class Backport:
         return ""
 
     def create_issue_if_not_exist(self):
-        title = "[backport %s] %s" % (self.__ver, self.__origin_issue.title)
+        title = "[backport %s] %s" % (self.__ver[0:self.__ver.rindex('.')], self.__origin_issue.title)
         body = "backport the issue #%s" % self.__origin_issue.number
 
         # return if the comment exists

--- a/github-bot/harvester_github_bot/zenhub.py
+++ b/github-bot/harvester_github_bot/zenhub.py
@@ -38,9 +38,9 @@ class Zenhub:
         releases = json.loads(resp.text)
         for r in releases:
             if r['title'] == version:
-                return r['release_id'], None
+                return r['release_id'], ""
 
-        return None, None
+        return None, ""
 
     def add_release_to_issue(self, repo_id, release_id, issue_number):
         add_issues = {'add_issues': [{'repo_id': repo_id, 'issue_number': issue_number}], 'remove_issues': []}


### PR DESCRIPTION
Problem:
Release is not automatically associated when a backport issue is created.

Solution:
fix err return empty string 
modify backport title display big version

Related Issue:
https://github.com/harvester/harvester/issues/2385

Test plan:
1. Create an issue or binding an existing issue with a backport label.
2. When an issue is created successfully or a backport label has been bound, an issue of type backport is automatically created.
3. View the backport issue title version and release

Note: a new issue will not be created if the milestone in the label is the same.