### PR TITLE
fix: unexpected behavior when creating multiple backport label

### DIFF
--- a/github-bot/harvester_github_bot/exception.py
+++ b/github-bot/harvester_github_bot/exception.py
@@ -1,0 +1,5 @@
+class CustomException (Exception):
+    pass
+
+class ExistedBackportComment (Exception):
+    pass


### PR DESCRIPTION
### Issues

https://github.com/harvester/bot/issues/11

1. First issue is that sometime it only created one backport issue.
2. Second issue is that create nested backport issue.
3. Third issue is that if you don't create milestone first, you can't create backport issue. If we all think we could create milestone first, I could change code back.

### Description

> Demo is below.

In original logic, if we add two backport label, it will just ***pick one label*** to backport unless you remember to remove backport label after backport issue is created. **That's why sometime it only created one backport issue.**

https://github.com/harvester/bot/blob/4343c6517be27f57902cd19b74e51b96785dc1c6/github-bot/harvester_github_bot/backport.py#L48-L52

As you can see, it only pops ***one backport label***, that means it will bring the remaining labels to new created backport issue. **That's why it creates nested backport issue** because new created issue has backport label.

So, I changed some data structure and reuse original class to allow we could create multiple backport labels at the same time, it means it supports following use cases.

- Add label `A`, then add label `B` immediately
- Add label `A` and `B` at the same time

I also used python native function to catch custom and unexpected exception.
