### PR TITLE
feat: create gui issue when assign require-ui label

### DIFF
--- a/github-bot/harvester_github_bot/action.py
+++ b/github-bot/harvester_github_bot/action.py
@@ -1,5 +1,28 @@
+import abc
+
 class ActionRequest:
     def __init__(self):
         pass
     def setAction(self, action):
         self.action = action
+
+
+class Action(abc.ABC):
+    # isMatched returns True if the actionRequest is matched with the action from github webook
+    @abc.abstractmethod
+    def isMatched(self, actionRequest):
+        raise NotImplementedError
+    
+    @abc.abstractmethod
+    def action(self, request):
+        raise NotImplementedError
+
+class LabelAction(abc.ABC):
+    # isMatched returns True if it meets the condition to execute the action
+    @abc.abstractmethod
+    def isMatched(self, request):
+        raise NotImplementedError
+    
+    @abc.abstractmethod
+    def action(self, request):
+        raise NotImplementedError

--- a/github-bot/harvester_github_bot/action.py
+++ b/github-bot/harvester_github_bot/action.py
@@ -1,0 +1,5 @@
+class ActionRequest:
+    def __init__(self):
+        pass
+    def setAction(self, action):
+        self.action = action

--- a/github-bot/harvester_github_bot/action_label.py
+++ b/github-bot/harvester_github_bot/action_label.py
@@ -1,13 +1,13 @@
 from harvester_github_bot.label_action.create_gui_issue import CreateGUIIssue
 from harvester_github_bot.label_action.create_backport import CreateBackport
-
+from harvester_github_bot.action import Action
 
 ALL_LABEL_ACTIONS = [
     CreateBackport,
     CreateGUIIssue
 ]
 
-class ActionLabel:
+class ActionLabel(Action):
     def __init__(self):
         pass
     

--- a/github-bot/harvester_github_bot/action_label.py
+++ b/github-bot/harvester_github_bot/action_label.py
@@ -1,0 +1,26 @@
+from harvester_github_bot.label_action.create_gui_issue import CreateGUIIssue
+from harvester_github_bot.label_action.create_backport import CreateBackport
+
+
+ALL_LABEL_ACTIONS = [
+    CreateBackport,
+    CreateGUIIssue
+]
+
+class ActionLabel:
+    def __init__(self):
+        pass
+    
+    def isMatched(self, actionRequest):
+        if actionRequest.action not in ['labeled']:
+            return False
+        return True
+    
+    def action(self, request):
+        for label_action in ALL_LABEL_ACTIONS:
+            __label_action = label_action()
+            if __label_action.isMatched(request):
+                __label_action.action(request)
+            
+        return "labeled related actions succeed"
+

--- a/github-bot/harvester_github_bot/action_sync_milestone.py
+++ b/github-bot/harvester_github_bot/action_sync_milestone.py
@@ -5,8 +5,8 @@ from harvester_github_bot.exception import CustomException
 class ActionSyncMilestone:
     def __init__(self):
         pass
-    def isMatched(self, action):
-        if action not in ['opened', 'milestoned', 'demilestoned']:
+    def isMatched(self, actionRequest):
+        if actionRequest.action not in ['opened', 'milestoned', 'demilestoned']:
             return False
         return True
     def action(self, request):

--- a/github-bot/harvester_github_bot/action_sync_milestone.py
+++ b/github-bot/harvester_github_bot/action_sync_milestone.py
@@ -1,8 +1,9 @@
 from harvester_github_bot import app
 from harvester_github_bot import zenh_api, repo
 from harvester_github_bot.exception import CustomException
+from harvester_github_bot.action import Action
 
-class ActionSyncMilestone:
+class ActionSyncMilestone(Action):
     def __init__(self):
         pass
     def isMatched(self, actionRequest):

--- a/github-bot/harvester_github_bot/label_action/create_backport.py
+++ b/github-bot/harvester_github_bot/label_action/create_backport.py
@@ -3,6 +3,7 @@ from harvester_github_bot import app, zenh_api, repo, \
     BACKPORT_LABEL_KEY
 from harvester_github_bot.exception import CustomException, ExistedBackportComment
 from harvester_github_bot.label_action.create_gui_issue import CREATE_GUI_ISSUE_LABEL
+from harvester_github_bot.action import LabelAction
 
 # check the issue's include backport-needed/(1.0.3|v1.0.3|v1.0.3-rc0) label
 backport_label_pattern = r'^%s\/[\w0-9\.]+' % BACKPORT_LABEL_KEY
@@ -13,7 +14,7 @@ backport_label_pattern = r'^%s\/[\w0-9\.]+' % BACKPORT_LABEL_KEY
 # Description: backport the issue #link-id
 # Copy assignees and all labels except the backport-needed and add the not-require/test-plan label.
 # Move the issue to the associated milestone and release.
-class CreateBackport:
+class CreateBackport(LabelAction):
     def __init__(self):
         pass
     

--- a/github-bot/harvester_github_bot/label_action/create_backport.py
+++ b/github-bot/harvester_github_bot/label_action/create_backport.py
@@ -2,16 +2,7 @@ import re
 from harvester_github_bot import app, zenh_api, repo, \
     BACKPORT_LABEL_KEY
 from harvester_github_bot.exception import CustomException, ExistedBackportComment
-
-class ActionBackport:
-    def __init__(self):
-        pass
-    def isMatched(self, action):
-        if action not in ['labeled']:
-            return False
-        return True
-    def action(self, request):
-        return backport(request)
+from harvester_github_bot.label_action.create_gui_issue import CREATE_GUI_ISSUE_LABEL
 
 # check the issue's include backport-needed/(1.0.3|v1.0.3|v1.0.3-rc0) label
 backport_label_pattern = r'^%s\/[\w0-9\.]+' % BACKPORT_LABEL_KEY
@@ -22,35 +13,47 @@ backport_label_pattern = r'^%s\/[\w0-9\.]+' % BACKPORT_LABEL_KEY
 # Description: backport the issue #link-id
 # Copy assignees and all labels except the backport-needed and add the not-require/test-plan label.
 # Move the issue to the associated milestone and release.
-def backport(request):
-    normal_labels = []
-    backport_labels = []
-    for label in request['issue']['labels']:
-        if re.match(backport_label_pattern, label['name']) is not None:
-            backport_labels.append(label)
-        else:
-            normal_labels.append(label)
-
-    msg = []
-    for backport_label in backport_labels:
-        try:
-            app.logger.debug(f"issue number {request['issue']['number']} start to create backport with labels {backport_label['name']}")
-            
-            bp = Backport(request['issue']['number'], normal_labels, backport_label)
-            bp.verify()
-            bp.create_issue_if_not_exist()
-            bp.create_comment()
-            r = bp.related_release()
-            msg.append(r)
-        except ExistedBackportComment as e:
-            app.logger.debug(f"issue number {request['issue']['number']} had created backport with labels {backport_label['name']}")
-        except CustomException as e:
-            app.logger.exception(f"Custom exception : {str(e)}")
-        except Exception as e:
-            app.logger.exception(e)
+class CreateBackport:
+    def __init__(self):
+        pass
     
-    return ",".join(msg)
+    def isMatched(self, request):
+        for label in request['issue']['labels']:
+            if re.match(backport_label_pattern, label['name']) is not None:
+                return True
+        return False
+                    
+    def action(self, request):
+        normal_labels = []
+        backport_labels = []
+        for label in request['issue']['labels']:
+            if re.match(backport_label_pattern, label['name']) is not None:
+                backport_labels.append(label)
+            else:
+                # backport should not include the 'require-ui' label
+                # because gui issue has its own backport
+                if CREATE_GUI_ISSUE_LABEL not in label['name']:
+                    normal_labels.append(label)
 
+        msg = []
+        for backport_label in backport_labels:
+            try:
+                app.logger.debug(f"issue number {request['issue']['number']} start to create backport with labels {backport_label['name']}")
+                
+                bp = Backport(request['issue']['number'], normal_labels, backport_label)
+                bp.verify()
+                bp.create_issue_if_not_exist()
+                bp.create_comment()
+                r = bp.related_release()
+                msg.append(r)
+            except ExistedBackportComment as e:
+                app.logger.debug(f"issue number {request['issue']['number']} had created backport with labels {backport_label['name']}")
+            except CustomException as e:
+                app.logger.exception(f"Custom exception : {str(e)}")
+            except Exception as e:
+                app.logger.exception(e)
+        
+        return ",".join(msg)
 
 class Backport:
     def __init__(

--- a/github-bot/harvester_github_bot/label_action/create_gui_issue.py
+++ b/github-bot/harvester_github_bot/label_action/create_gui_issue.py
@@ -1,0 +1,54 @@
+from harvester_github_bot import app
+from harvester_github_bot import zenh_api, repo
+from harvester_github_bot.exception import CustomException
+import re
+
+CREATE_GUI_ISSUE_LABEL = "require-ui"
+
+class CreateGUIIssue:
+    def __init__(self):
+        pass
+    
+    def isMatched(self, request):
+        for label in request['issue']['labels']:
+            if CREATE_GUI_ISSUE_LABEL  in label['name']:
+                return True
+        return False
+            
+    def action(self, request):
+        self.labels = ["area/ui"]
+        
+        for label in request['issue']['labels']:
+            if CREATE_GUI_ISSUE_LABEL not in label['name']:
+                self.labels.append(label['name'])
+    
+        self.issue_number = request['issue']['number']
+        self.original_issue = repo.get_issue(self.issue_number)
+        
+        if self.__is_gui_issue_exist():
+            return "GUI issue already exist"
+        self.__create_gui_issue()
+        self.__create_comment()
+        return "create GUI issue success"
+    
+    def __create_gui_issue(self):
+        issue_data = {
+            'title': f"[GUI] {self.original_issue.title}",
+            'body': f"GUI Issue from #{self.issue_number}",
+            'labels': self.labels,
+            'assignees': self.original_issue.assignees,
+        }
+        if self.original_issue.milestone is not None:
+            issue_data['milestone'] = self.original_issue.milestone
+        self.gui_issue = repo.create_issue(**issue_data)
+        
+    def __create_comment(self):
+        self.original_issue.create_comment(body=f"GUI issue created #{self.gui_issue.number}.")
+        
+    def __is_gui_issue_exist(self):
+        comment_pattern = r'GUI issue created #[\d].'
+        comments = self.original_issue.get_comments()
+        for comment in comments:
+            if re.match(comment_pattern, comment.body):
+                return True
+        return False

--- a/github-bot/harvester_github_bot/label_action/create_gui_issue.py
+++ b/github-bot/harvester_github_bot/label_action/create_gui_issue.py
@@ -11,6 +11,11 @@ class CreateGUIIssue(LabelAction):
     def isMatched(self, request):
         matched = False
         
+        # We can't expect the labels order from Github Webhook request.
+        # It might be ["require-ui/small", "area/ui"] or ["area/ui", "require-ui/small"]
+        # So we need to consider those two cases.
+        # "area/ui" is high priority label.
+        # If "area/ui" is in the labels, we can skip the rest of the labels.
         for label in request['issue']['labels']:
             if AREA_UI_LABEL in label['name']:
                 return False

--- a/github-bot/harvester_github_bot/label_action/create_gui_issue.py
+++ b/github-bot/harvester_github_bot/label_action/create_gui_issue.py
@@ -3,19 +3,24 @@ from harvester_github_bot.action import LabelAction
 import re
 
 CREATE_GUI_ISSUE_LABEL = "require-ui"
-
+AREA_UI_LABEL = "area/ui"
 class CreateGUIIssue(LabelAction):
     def __init__(self):
         pass
     
     def isMatched(self, request):
+        matched = False
+        
         for label in request['issue']['labels']:
+            if AREA_UI_LABEL in label['name']:
+                return False
             if CREATE_GUI_ISSUE_LABEL  in label['name']:
-                return True
-        return False
+                matched = True
+            
+        return matched
             
     def action(self, request):
-        self.labels = ["area/ui"]
+        self.labels = [AREA_UI_LABEL]
         
         for label in request['issue']['labels']:
             if CREATE_GUI_ISSUE_LABEL not in label['name']:

--- a/github-bot/harvester_github_bot/label_action/create_gui_issue.py
+++ b/github-bot/harvester_github_bot/label_action/create_gui_issue.py
@@ -1,11 +1,10 @@
-from harvester_github_bot import app
-from harvester_github_bot import zenh_api, repo
-from harvester_github_bot.exception import CustomException
+from harvester_github_bot import repo
+from harvester_github_bot.action import LabelAction
 import re
 
 CREATE_GUI_ISSUE_LABEL = "require-ui"
 
-class CreateGUIIssue:
+class CreateGUIIssue(LabelAction):
     def __init__(self):
         pass
     

--- a/github-bot/harvester_github_bot/route.py
+++ b/github-bot/harvester_github_bot/route.py
@@ -55,11 +55,11 @@ def gh():
             'message': msg
         }, http.HTTPStatus.OK
         
-    actionRequest = ActionRequest()
-    actionRequest.setAction(req.get('action'))
+    action_request = ActionRequest()
+    action_request.setAction(req.get('action'))
     
     for action in SUPPORTED_ACTIONS:
-        if action.isMatched(actionRequest):
+        if action.isMatched(action_request):
             msg = action.action(req)
             break
 

--- a/github-bot/harvester_github_bot/route.py
+++ b/github-bot/harvester_github_bot/route.py
@@ -6,7 +6,8 @@ from werkzeug.security import check_password_hash
 
 from harvester_github_bot.config import app, FLASK_USERNAME, FLASK_PASSWORD, GITHUB_OWNER, GITHUB_REPOSITORY
 from harvester_github_bot.issue_transfer import issue_transfer
-from harvester_github_bot.action_backport import ActionBackport
+from harvester_github_bot.action import ActionRequest
+from harvester_github_bot.action_label import ActionLabel
 from harvester_github_bot.action_sync_milestone import ActionSyncMilestone
 
 auth = HTTPBasicAuth()
@@ -39,7 +40,7 @@ def zenhub():
 
 
 SUPPORTED_ACTIONS = [
-    ActionBackport(),
+    ActionLabel(),
     ActionSyncMilestone(),
 ]
 
@@ -53,9 +54,12 @@ def gh():
         return {
             'message': msg
         }, http.HTTPStatus.OK
+        
+    actionRequest = ActionRequest()
+    actionRequest.setAction(req.get('action'))
     
     for action in SUPPORTED_ACTIONS:
-        if action.isMatched(req.get('action')):
+        if action.isMatched(actionRequest):
             msg = action.action(req)
             break
 


### PR DESCRIPTION
These are examples for labeling backport and require-ui:

- Label one backport and one require-ui https://github.com/Yu-Jack/test/issues/155
  - One main issue
  - One backport issue from main issue
  - One GUI Issue
  - One backport issue from GUI issue
- Label two backports and one require-ui https://github.com/Yu-Jack/test/issues/144
  - One main issue
  - Two backports issues from main issue
  - One GUI issue
  - Two backports issues from GUI issue
- Label one require-ui https://github.com/Yu-Jack/test/issues/150
  - One GUI issue
  - **If we just create GUI issue, we don't need to assign milestone for it.**
  - Of course, we could create backport in GUI issue as well. https://github.com/Yu-Jack/test/issues/153

**Currently, I will sync backport labels when I create the GUI issue cause. If we don't want that, I could remove that logic.**


https://github.com/harvester/bot/issues/25